### PR TITLE
Adds wrap-reload and cider-nrepl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,10 @@
                  [clj-time "0.11.0"]
                  [org.clojure/java.jdbc "0.4.2"]
                  [org.postgresql/postgresql "9.4.1207.jre7"]
-                 [commons-validator/commons-validator "1.4.0"]]
+                 [commons-validator/commons-validator "1.4.0"]
+                 [ring/ring-devel "1.3.0"]
+                 [org.clojure/tools.nrepl "0.2.12"]
+                 [cider/cider-nrepl "0.12.0"]]
   :main ^:skip-aot lunchselector.app
   :target-path "target/%s"
   :plugins [[lein-ring "0.9.7"]]

--- a/src/lunchselector/app.clj
+++ b/src/lunchselector/app.clj
@@ -4,19 +4,22 @@
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.session :refer [wrap-session]]
             [ring.middleware.cookies :refer [wrap-cookies]]
+            [ring.middleware.reload :refer [wrap-reload]]
             [bidi.ring :as bidi]
             [lunchselector.utils :as utils]
-            [lunchselector.core :as core]))
+            [lunchselector.core :as core]
+            [clojure.tools.nrepl.server :as nrepl-server]
+            [cider.nrepl :refer (cider-nrepl-handler)]))
 
 (def handler
   (bidi/make-handler
    ["/" { "" core/home
-          "restaurants" core/restaurants
-          "login" core/login
-          "vote" core/vote
-          "result" core/result
-          "add-offline-restaurants" core/add-offline-restaurants
-          "slack" core/slack}]))
+         "restaurants" core/restaurants
+         "login" core/login
+         "vote" core/vote
+         "result" core/result
+         "add-offline-restaurants" core/add-offline-restaurants
+         "slack" core/slack}]))
 
 (def lunch-app
   (-> handler
@@ -26,4 +29,5 @@
 
 (defn -main []
   (utils/initialize-app-configuration)
-  (server/run-server lunch-app {:port (utils/get-config :server-port)}))
+  (nrepl-server/start-server :port 3001 :handler cider-nrepl-handler)
+  (server/run-server (wrap-reload #'lunch-app) {:port (utils/get-config :server-port)}))


### PR DESCRIPTION
adds `wrap-reload` and `cider-nrepl` so as to implement hot-loading of the code and running a cider-nrepl port when the server is started.
